### PR TITLE
ci: grant the access of "update-flake-lock" action to trigger rebuilds

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -22,3 +22,4 @@ jobs:
           pr-labels: |                  # Labels to be set on the PR
             dependencies
             automated
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}


### PR DESCRIPTION
Link: https://github.com/DeterminateSystems/update-flake-lock#with-a-personal-authentication-token