### PR TITLE
nixos: libvirt -> qemu scripts

### DIFF
--- a/nixos/configurations/adrastea/default.nix
+++ b/nixos/configurations/adrastea/default.nix
@@ -53,8 +53,11 @@
   ] ++ (with pkgs; [
     musescore
     gnumake
-    virt-manager
+    qemu
+    virt-viewer
   ]);
+
+  virtualisation.spiceUSBRedirection.enable = true;
 
   nixpkgs.config.permittedInsecurePackages = [
     "electron-19.0.7"
@@ -78,10 +81,6 @@
   # virtualisation.virtualbox.host.enableExtensionPack = true;
   # virtualisation.virtualbox.host.enable = true;
   # users.extraGroups.vboxusers.members = [ "lyc" ];
-
-  virtualisation.libvirtd.enable = true;
-  programs.dconf.enable = true;
-  users.extraGroups.libvirtd.members = [ "lyc" ];
 
   virtualisation.podman = {
     enable = true;

--- a/nixos/configurations/adrastea/default.nix
+++ b/nixos/configurations/adrastea/default.nix
@@ -59,6 +59,14 @@
 
   virtualisation.spiceUSBRedirection.enable = true;
 
+
+  # Grant non-privileged users to access USB devices
+  # For rootlesss USB forwarding (without SPICE)
+  services.udev.extraRules = ''
+    SUBSYSTEM=="usb", GROUP="users", MODE="0660"
+    SUBSYSTEM=="usb_device", GROUP="users", MODE="0660"
+  '';
+
   nixpkgs.config.permittedInsecurePackages = [
     "electron-19.0.7"
   ];


### PR DESCRIPTION
Currently libvirt + virt-manager have a few things I do not happy with:

- Root privileges & daemon service.
- XML, that's a nightmare for humans.
- Inflexible, because of XML. It's not easy to change configurations.
- Default to SPICE servers, although sometimes I prefer other QEMU displays.

Fixes: #53