### PR TITLE
home/vscode: use package absolute path

### DIFF
--- a/home/lyc/configurations/adrastea/vscode-settings.json
+++ b/home/lyc/configurations/adrastea/vscode-settings.json
@@ -1,6 +1,5 @@
 {
     "editor.fontSize": 21,
-    "vscode-neovim.neovimExecutablePaths.linux": "/run/current-system/sw/bin/nvim",
     "terminal.integrated.profiles.linux": {
         "bash": {
             "icon": "terminal-bash",
@@ -20,8 +19,7 @@
         "zsh": {
             "args": [
                 "-l"
-            ],
-            "path": "zsh"
+            ]
         }
     },
     "terminal.integrated.defaultProfile.linux": "zsh"

--- a/home/lyc/configurations/amalthea/vscode-settings.json
+++ b/home/lyc/configurations/amalthea/vscode-settings.json
@@ -24,10 +24,8 @@
         "zsh": {
             "args": [
                 "-l"
-            ],
-            "path": "/Users/inclyc/.nix-profile/bin/zsh"
+            ]
         }
     },
-    "vscode-neovim.neovimExecutablePaths.darwin": "/Users/inclyc/.nix-profile/bin/nvim",
     "editor.fontSize": 16
 }

--- a/home/lyc/modules/programs/vscode/vscode.nix
+++ b/home/lyc/modules/programs/vscode/vscode.nix
@@ -7,7 +7,23 @@
 {
   programs.vscode = {
     enable = lib.mkDefault false;
-    userSettings = (builtins.fromJSON (builtins.readFile ./settings.json));
+    userSettings = (builtins.fromJSON (builtins.readFile ./settings.json)) //
+      (
+        let
+          nvimPath = "${pkgs.neovim}/bin/nvim";
+          zshPath = "${pkgs.zsh}/bin/zsh";
+        in
+        {
+          # path.linux may specified "incorrectly" on darwin
+          # because it will link to *darwin* executable. This configuration
+          # should be evaulated on corresponding platform, and choosed by vscode.
+          "vscode-neovim.neovimExecutablePaths.linux" = nvimPath;
+          "vscode-neovim.neovimExecutablePaths.darwin" = nvimPath;
+
+          "terminal.integrated.profiles.osx".zsh.path = zshPath;
+          "terminal.integrated.profiles.linux".zsh.path = zshPath;
+        }
+      );
     extensions = with inputs.nix-vscode-extensions.extensions.${system}.vscode-marketplace; [
       llvm-vs-code-extensions.vscode-clangd
       jnoortheen.nix-ide


### PR DESCRIPTION
Previousely, executable paths in vscode are specified basically using "environmental" profiles.

Assuming that directories: (1) /run/current-system/sw/bin
                           (2) ~/.nix-profile/bin

include our desired package. However, these paths may not equal to actual store paths, or might be changed (e.g. ~/.nix-profile).

So using "store" path, which should be evaulated by nix, and sematicaly declared the dependence. (vscode -> neovim)