### PR TITLE
home: use `pinentryFlavor = "curses";` for gpg-agent

### DIFF
--- a/home/lyc/configurations/adrastea/default.nix
+++ b/home/lyc/configurations/adrastea/default.nix
@@ -31,9 +31,7 @@
 
   services.gpg-agent = {
     enable = true;
-    extraConfig = ''
-      pinentry-program ${pkgs.pinentry-curses}/bin/pinentry-curses
-    '';
+    pinentryFlavor = "curses";
   };
 
   programs.zsh.dirHashes = {

--- a/home/lyc/configurations/aplaz/default.nix
+++ b/home/lyc/configurations/aplaz/default.nix
@@ -13,8 +13,6 @@
 
   services.gpg-agent = {
     enable = true;
-    extraConfig = ''
-      pinentry-program ${pkgs.pinentry-curses}/bin/pinentry-curses
-    '';
+    pinentryFlavor = "curses";
   };
 }

--- a/home/lyc/configurations/metis/default.nix
+++ b/home/lyc/configurations/metis/default.nix
@@ -10,4 +10,9 @@
     from = { type = "indirect"; id = "home"; };
     flake = inputs.nixpkgs-stable;
   };
+
+  services.gpg-agent = {
+    enable = true;
+    pinentryFlavor = "curses";
+  };
 }


### PR DESCRIPTION
This fixes recent breaking change in nixpkgs.