### PR TITLE
nixos/aplaz: set hid fn mode to 2

### DIFF
--- a/nixos/configurations/aplaz/default.nix
+++ b/nixos/configurations/aplaz/default.nix
@@ -45,6 +45,8 @@
     "/nix".options = [ "compress=zstd" "noatime" ];
   };
 
+  boot.kernelParams = [ "hid_apple.fnmode=2" ];
+
 
   systemd.oomd.enableRootSlice = true;
   systemd.oomd.enableUserSlices = true;


### PR DESCRIPTION
To make the Fn keys work as Fn keys, not media keys.