### PR TITLE
nixos/configurations/metis/oparic: fix wrong directive for matomo

### DIFF
--- a/nixos/configurations/metis/oparic/default.nix
+++ b/nixos/configurations/metis/oparic/default.nix
@@ -57,7 +57,7 @@ in
         extraConfig = "reverse_proxy 192.168.31.5:80";
       };
       "matomo.inclyc.cn" = {
-        extraConfig = "php_fastcgi 192.168.31.5:9000";
+        extraConfig = "reverse_proxy 192.168.31.5:9000";
       };
     };
   };


### PR DESCRIPTION
php, 太困难了. 已 switch